### PR TITLE
added vscode setting

### DIFF
--- a/templates/typescript/config/.vscode/settings.json
+++ b/templates/typescript/config/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "scss.validate": false
+}


### PR DESCRIPTION
When creating and running an SL-app, SCSS files throw these annoying lines when using tailwind:
![Screenshot 2022-01-31 at 09 57 02](https://user-images.githubusercontent.com/60095327/151767531-4f4fb1df-5635-4655-b62c-c2968cc9824d.png)

To fix this, I added a vscode setting, after which it looks good:
![Screenshot 2022-01-31 at 09 57 16](https://user-images.githubusercontent.com/60095327/151767616-4182561c-4a8c-481f-b1d8-05458e7bcbcd.png)

I tested it, and we can write working tailwind syntax in SCSS files with no problem, regardless of these squiggly lines.

We could also fix this locally in our own vscode settings, instead of having it as part of the project. Let me know what you think!
